### PR TITLE
Adds saving .mscz functionality

### DIFF
--- a/mscxyz/score_file_classes.py
+++ b/mscxyz/score_file_classes.py
@@ -112,8 +112,6 @@ class MscoreFile(object):
         else:
             self.loadpath = self.abspath
 
-        self.tmpvar = "temp"
-
     @staticmethod
     def _unzip(abspath: str):
         tmp_zipdir = tempfile.mkdtemp()


### PR DESCRIPTION
In the save() method, I added additional functionality to save individual files from unzipped tmp directory back into the original .mscz file (when .mscz is used).